### PR TITLE
Chore: add node modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# npm packages
+node_modules


### PR DESCRIPTION
Add dependencies to git ignore so that they won't be tracked by git. Not sure if it is a relevant change, but I felt it is good to have :) 