### PR TITLE
Display a list of projects instead of the raw python object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
-  "name": "dashboard",
-  "version": "0.0.1",
-  "dependencies": {
-    "@patternfly/patternfly": "^2.46.1",
-    "patternfly": "^3.59.4"
-  },
-  "devDependencies": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://gitlab.com/github.com/packit-service/dashboard.git"
-  },
-  "license": "MIT"
+    "name": "dashboard",
+    "version": "0.0.1",
+    "dependencies": {"@patternfly/patternfly": "^2.46.1", "patternfly": "^3.59.4"},
+    "devDependencies": {},
+    "repository": {
+        "type": "git",
+        "url": "git+https://gitlab.com/github.com/packit-service/dashboard.git",
+    },
+    "license": "MIT",
 }

--- a/packit_dashboard/app.py
+++ b/packit_dashboard/app.py
@@ -22,7 +22,9 @@ def node_modules(filename):
 @app.route("/")
 def main():
     return render_template(
-        "main_frame.html", content=render_template("information.html"),
+        "main_frame.html",
+        header="Information",
+        content=render_template("information.html"),
     )
 
 
@@ -75,7 +77,7 @@ def projects():
 
     for build in all_from(f"{API_URL}/copr-builds"):
         if not isinstance(build, dict) or not all(
-                [build.get("project"), build.get("status")]
+            [build.get("project"), build.get("status")]
         ):
             continue
         name = build["project"]
@@ -92,11 +94,12 @@ def projects():
     content = render_template(
         "projects.html",
         counter=len(all_projects),
-        all_projects=str(all_projects),
+        all_projects=all_projects,
         counter_s=len(successful_projects),
-        successful_projects=str(successful_projects),
+        successful_projects=successful_projects,
     )
     return render_template("main_frame.html", header="Project", content=content)
+
 
 @app.route("/builds/")
 def builds():
@@ -105,10 +108,7 @@ def builds():
     # TODO Add button/table navigation to load more
     json_url = f"{API_URL}/copr-builds?page=1&per_page=20"
     api_data = requests.get(url=json_url).json()
-    content = render_template(
-        "builds.html",
-        builds_list = api_data
-    )
+    content = render_template("builds.html", builds_list=api_data)
     return render_template("main_frame.html", header="Builds", content=content)
 
 

--- a/templates/main_frame.html
+++ b/templates/main_frame.html
@@ -44,7 +44,7 @@
       <main role="main" class="pf-c-page__main" tabindex="-1" id="main-content-page-layout-horizontal-nav">
         <section class="pf-c-page__main-section pf-m-light">
           <div class="pf-c-content">
-            <h1> Information </h1>
+            <h1> {{header}} </h1>
           </div>
         </section>
         <section class="pf-c-page__main-section pf-m-light">

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -1,9 +1,44 @@
-<h2> Total projects: {{ counter }} </h2>
-(Projects which ever used (i.e. were building their PR code in Copr via) Packit service)
-<p><p>
-{{ all_projects|safe }}
+<ul class="pf-c-data-list" role="list" aria-label="Basic data list example" id="data-list-basic">
+    <li class="pf-c-data-list__item" aria-labelledby="data-list-basic-item1">
+        <div class="pf-c-data-list__item-row">
+            <div class="pf-c-data-list__item-content">
+                <div class="pf-c-data-list__cell">
+                    <span id="data-list-basic-item1">
+                        <h2> Total projects: {{ counter }} </h2>
+                        (Projects which ever used (i.e. were building their PR code in Copr via) Packit service)
+                        <p>
+                            <ul>
+                                {% for project in all_projects %}
+                                <li>{{ project }}</li>
+                                {% endfor %}
+                            </ul>
 
-<h2> Successful projects: {{ counter_s }} </h2>
-(Projects which ever successfully used (i.e. successfully built their PR code in Copr in all targets via) Packit service)
-<p><p>
-{{ successful_projects|safe }}
+                        </p>
+                    </span>
+                </div>
+
+            </div>
+        </div>
+    </li>
+    <li class="pf-c-data-list__item" aria-labelledby="data-list-basic-item2">
+        <div class="pf-c-data-list__item-row">
+            <div class="pf-c-data-list__item-content">
+                <div class="pf-c-data-list__cell">
+                    <span id="data-list-basic-item2">
+                        <h2> Successful projects: {{ counter_s }} </h2>
+                        (Projects which ever successfully used (i.e. successfully built their PR code in Copr in all
+                        targets via) Packit service)
+                        <p>
+                            <ul>
+                                {% for project in successful_projects %}
+                                <li>{{ project }}</li>
+                                {% endfor %}
+                            </ul>
+
+                        </p>
+                    </span>
+                </div>
+
+            </div>
+    </li>
+</ul>


### PR DESCRIPTION
- Replaced the raw object in the projects tab with a list. 
- I also ran black on the entire repo so some code was reformatted.
- Replaced the hardcoded word "information" (which was shown in every tab) with respective headers for each tab.

![Screenshot_2020-03-04 Screenshot](https://user-images.githubusercontent.com/18102790/75874634-275ff100-5e38-11ea-88f4-fd9854d93156.png)
