### PR TITLE
Cache API requests and wait before retrying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TEST_TARGET ?= ./tests/
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
 
 install-dependencies:
-	sudo dnf -y install python3-flask yarnpkg
+	sudo dnf -y install python3-flask python3-flask-caching yarnpkg
 	yarn install
 
 transpile-prod:

--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -9,6 +9,7 @@
         name:
           - python3-pip
           - python3-flask
+          - python3-flask-caching
           - python3-requests
           - npm
           - nss_wrapper

--- a/packit_dashboard/api/routes.py
+++ b/packit_dashboard/api/routes.py
@@ -1,16 +1,17 @@
 from flask import Blueprint, jsonify, request
+from packit_dashboard.cache import cache
 from packit_dashboard.utils import return_json
 from packit_dashboard.config import API_URL
 
-api = Blueprint("api", __name__)
 
+api = Blueprint("api", __name__)
 # The react frontend will request information here instead of fetching directly
 # from the main API.
 # This is because it will be easier to implement caching API requests here.
-# (Flask-Caching etc)
 
 
 @api.route("/api/copr-builds/")
+@cache.cached(timeout=60, query_string=True)  # cache for 60s
 def copr_builds():
     page = request.args.get("page")
     per_page = request.args.get("per_page")
@@ -19,6 +20,7 @@ def copr_builds():
 
 
 @api.route("/api/testing-farm/")
+@cache.cached(timeout=60, query_string=True)
 def testing_farm():
     page = request.args.get("page")
     per_page = request.args.get("per_page")

--- a/packit_dashboard/app.py
+++ b/packit_dashboard/app.py
@@ -1,9 +1,10 @@
 from flask import Flask
+from packit_dashboard.cache import cache
 from packit_dashboard.home.routes import home
 from packit_dashboard.api.routes import api
 
 app = Flask("Packit Service Dashboard")
-
+cache.init_app(app)
 
 app.register_blueprint(api)
 # Note: Declare any other flask blueprints or routes above this

--- a/packit_dashboard/cache.py
+++ b/packit_dashboard/cache.py
@@ -1,0 +1,9 @@
+from flask_caching import Cache
+
+cache = Cache(
+    config={
+        "CACHE_TYPE": "filesystem",
+        "CACHE_DEFAULT_TIMEOUT": 120,
+        "CACHE_DIR": "/tmp",
+    }
+)

--- a/packit_dashboard/utils.py
+++ b/packit_dashboard/utils.py
@@ -1,14 +1,15 @@
 import requests
 import json
+import time
 
 
 # Common utility functions used in multiple files in the packit_dashboard package
-# Returns python parsable json object from URL
+
+
 def return_json(url, method="GET", **kwargs):
-
+    """ Returns python parsable json object from URL. """
     output = None
-
-    tries = 6
+    tries = 20
     for i in range(tries):
         try:
             response = requests.request(method=method, url=url, **kwargs)
@@ -16,6 +17,7 @@ def return_json(url, method="GET", **kwargs):
             print(f"Try-{i}")
         except Exception:
             if i < tries - 1:
+                time.sleep(0.5)
                 continue
             else:
                 output = None


### PR DESCRIPTION
Packit Service API fails to respond when faced with concurrent requests. We should fix this issue there too but we don't know the exact cause

In the meantime, caching and retrying here helps.

