### PR TITLE
Copr build tweaks

### DIFF
--- a/frontend/components/copr_builds_table.js
+++ b/frontend/components/copr_builds_table.js
@@ -7,6 +7,7 @@ import {
     TableVariant,
     sortable,
     SortByDirection,
+    cellWidth,
 } from "@patternfly/react-table";
 
 import { Button, Label, Tooltip } from "@patternfly/react-core";
@@ -24,27 +25,27 @@ const StatusLabel = (props) => {
             case "success":
                 statusLabelList.push(
                     <Tooltip content={props.list[chroot]}>
-                        <div style={{ padding: "2px" }}>
+                        <span style={{ padding: "2px" }}>
                             <Label color="green">{chroot}</Label>
-                        </div>
+                        </span>
                     </Tooltip>
                 );
                 break;
             case "failure":
                 statusLabelList.push(
                     <Tooltip content={props.list[chroot]}>
-                        <div style={{ padding: "2px" }}>
+                        <span style={{ padding: "2px" }}>
                             <Label color="red">{chroot}</Label>
-                        </div>
+                        </span>
                     </Tooltip>
                 );
                 break;
             default:
                 statusLabelList.push(
                     <Tooltip content={props.list[chroot]}>
-                        <div style={{ padding: "2px" }}>
+                        <span style={{ padding: "2px" }}>
                             <Label color="purple">{chroot}</Label>
-                        </div>
+                        </span>
                     </Tooltip>
                 );
         }
@@ -55,10 +56,10 @@ const StatusLabel = (props) => {
 const CoprBuildsTable = () => {
     // Headings
     const column_list = [
-        "PR",
+        { title: "PR", transforms: [cellWidth(25)] },
         "Chroots",
-        { title: "Time Submitted", transforms: [sortable] },
-        { title: "Build ID", transforms: [sortable] },
+        { title: "Time Submitted", transforms: [sortable, cellWidth(15)] },
+        { title: "Build ID", transforms: [sortable, cellWidth(15)] },
         // "Ref",
     ];
 

--- a/frontend/components/copr_builds_table.js
+++ b/frontend/components/copr_builds_table.js
@@ -73,8 +73,8 @@ const CoprBuildsTable = () => {
 
     // Fetch data from dashboard backend (or if we want, directly from the API)
     function fetchData() {
-        console.log(`Route is /api/copr-builds/?page=${page}&per_page=10`);
-        fetch(`/api/copr-builds/?page=${page}&per_page=10`)
+        console.log(`Route is /api/copr-builds/?page=${page}&per_page=20`);
+        fetch(`/api/copr-builds/?page=${page}&per_page=20`)
             .then((response) => response.json())
             .then((data) => {
                 jsonToRow(data);


### PR DESCRIPTION
Make the table on the Copr builds tab more compact by inlining the chroot labels and display 20 jobs by default.